### PR TITLE
Keep the current user logged in after password change

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,2 +1,4 @@
 //= link_tree ../images
 //= link_directory ../stylesheets .css
+//= link_tree ../../javascript .js
+//= link_tree ../../../vendor/javascript .js

--- a/app/controllers/users/profiles_controller.rb
+++ b/app/controllers/users/profiles_controller.rb
@@ -1,7 +1,9 @@
 class Users::ProfilesController < ApplicationController
   before_action :authenticate_user!
   layout 'logged_in'
+
   before_action :set_user, only: [:edit, :update]
+  after_action :invalidate_sessions, only: [:update]
 
   def edit;end
 
@@ -35,5 +37,9 @@ class Users::ProfilesController < ApplicationController
 
   def set_user
     @user = current_user
+  end
+
+  def invalidate_sessions
+    @user.forget_me! if @user.saved_change_to_encrypted_password? && params[:log_out_of_all_devices] == '1'
   end
 end

--- a/app/controllers/users/profiles_controller.rb
+++ b/app/controllers/users/profiles_controller.rb
@@ -3,7 +3,7 @@ class Users::ProfilesController < ApplicationController
   layout 'logged_in'
 
   before_action :set_user, only: [:edit, :update]
-  after_action :invalidate_sessions, only: [:update]
+  after_action :keep_current_session, only: [:update]
 
   def edit;end
 
@@ -39,7 +39,7 @@ class Users::ProfilesController < ApplicationController
     @user = current_user
   end
 
-  def invalidate_sessions
-    @user.forget_me! if @user.saved_change_to_encrypted_password? && params[:log_out_of_all_devices] == '1'
+  def keep_current_session
+    bypass_sign_in(@user) if @user.saved_change_to_encrypted_password? && params[:keep_logged_in] == '1'
   end
 end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,0 +1,2 @@
+// Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
+import "controllers"

--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -1,0 +1,9 @@
+import { Application } from "@hotwired/stimulus"
+
+const application = Application.start()
+
+// Configure Stimulus development experience
+application.debug = false
+window.Stimulus   = application
+
+export { application }

--- a/app/javascript/controllers/disable_keep_loggin_controller.js
+++ b/app/javascript/controllers/disable_keep_loggin_controller.js
@@ -4,18 +4,17 @@ export default class extends Controller {
   static targets = [
     "password",
     "confirmPassword",
-    "logoutCheckbox",
+    "keepLogginCheckbox",
   ]
 
   connect() {
-    console.log('slakalskdjlasjdlaskjdlkj')
-    this.toggleLogoutCheckbox()
+    this.toggleKeepLogginCheckbox()
   }
 
-  toggleLogoutCheckbox() {
+  toggleKeepLogginCheckbox() {
     const passwordFilled = this.passwordTarget.value.trim() !== ""
     const confirmPasswordFilled = this.confirmPasswordTarget.value.trim() !== ""
 
-    this.logoutCheckboxTarget.disabled = !(passwordFilled && confirmPasswordFilled)
+    this.keepLogginCheckboxTarget.disabled = !(passwordFilled && confirmPasswordFilled)
   }
 }

--- a/app/javascript/controllers/disable_logout_controller.js
+++ b/app/javascript/controllers/disable_logout_controller.js
@@ -1,0 +1,21 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = [
+    "password",
+    "confirmPassword",
+    "logoutCheckbox",
+  ]
+
+  connect() {
+    console.log('slakalskdjlasjdlaskjdlkj')
+    this.toggleLogoutCheckbox()
+  }
+
+  toggleLogoutCheckbox() {
+    const passwordFilled = this.passwordTarget.value.trim() !== ""
+    const confirmPasswordFilled = this.confirmPasswordTarget.value.trim() !== ""
+
+    this.logoutCheckboxTarget.disabled = !(passwordFilled && confirmPasswordFilled)
+  }
+}

--- a/app/javascript/controllers/hello_controller.js
+++ b/app/javascript/controllers/hello_controller.js
@@ -1,0 +1,7 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  connect() {
+    this.element.textContent = "Hello World!"
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -1,0 +1,4 @@
+// Import and register all your controllers from the importmap via controllers/**/*_controller
+import { application } from "controllers/application"
+import { eagerLoadControllersFrom } from "@hotwired/stimulus-loading"
+eagerLoadControllersFrom("controllers", application)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,6 +14,8 @@
     <link rel="icon" href="/icon.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" href="/icon.png">
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+    <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
+    <%= javascript_importmap_tags %>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-4Q6Gf2aSP4eDXB8Miphtr37CMZZQ5oXLH2yaXMJ2w8e2ZtHTl7GptT4jmndRuHDT" crossorigin="anonymous">
   </head>
 

--- a/app/views/layouts/logged_in.html.erb
+++ b/app/views/layouts/logged_in.html.erb
@@ -14,6 +14,8 @@
     <link rel="icon" href="/icon.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" href="/icon.png">
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+    <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
+    <%= javascript_importmap_tags %>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-4Q6Gf2aSP4eDXB8Miphtr37CMZZQ5oXLH2yaXMJ2w8e2ZtHTl7GptT4jmndRuHDT" crossorigin="anonymous">
   </head>
   <body>

--- a/app/views/users/profiles/edit.html.erb
+++ b/app/views/users/profiles/edit.html.erb
@@ -21,14 +21,14 @@
     <%= f.password_field :current_password, class: "form-control" %>
   </div>
 
-  <div data-controller="disable-logout">
+  <div data-controller="disable-keep-loggin">
     <div class="mb-3">
       <%= f.label :password %>
       <%= f.password_field :password,
             class: "form-control",
             data: {
-              disable_logout_target: 'password',
-              action: 'input->disable-logout#toggleLogoutCheckbox'
+              disable_keep_loggin_target: 'password',
+              action: 'input->disable-keep-loggin#toggleKeepLogginCheckbox'
             } %>
     </div>
 
@@ -37,15 +37,15 @@
       <%= f.password_field :password_confirmation,
             class: "form-control",
             data: {
-              disable_logout_target: 'confirmPassword',
-              action: 'input->disable-logout#toggleLogoutCheckbox'
+              disable_keep_loggin_target: 'confirmPassword',
+              action: 'input->disable-keep-loggin#toggleKeepLogginCheckbox'
             } %>
     </div>
 
     <div class="mb-3">
-      <%= label_tag 'log_out_of_all_devices' do %>
-        <%= check_box_tag 'log_out_of_all_devices', '1', false, data: { disable_logout_target: 'logoutCheckbox' } %>
-        <%= t('.log_out_of_all_devices', default: 'Log out of all devices') %>
+      <%= label_tag 'keep_logged_in' do %>
+        <%= check_box_tag 'keep_logged_in', '1', false, data: { disable_keep_loggin_target: 'keepLogginCheckbox' } %>
+        <%= t('.keep_logged_in', default: 'Keep logged in on this browser?') %>
       <% end %>
     </div>
   </div>

--- a/app/views/users/profiles/edit.html.erb
+++ b/app/views/users/profiles/edit.html.erb
@@ -21,14 +21,33 @@
     <%= f.password_field :current_password, class: "form-control" %>
   </div>
 
-  <div class="mb-3">
-    <%= f.label :password %>
-    <%= f.password_field :password, class: "form-control" %>
-  </div>
+  <div data-controller="disable-logout">
+    <div class="mb-3">
+      <%= f.label :password %>
+      <%= f.password_field :password,
+            class: "form-control",
+            data: {
+              disable_logout_target: 'password',
+              action: 'input->disable-logout#toggleLogoutCheckbox'
+            } %>
+    </div>
 
-  <div class="mb-3">
-    <%= f.label :password_confirmation %>
-    <%= f.password_field :password_confirmation, class: "form-control" %>
+    <div class="mb-3">
+      <%= f.label :password_confirmation %>
+      <%= f.password_field :password_confirmation,
+            class: "form-control",
+            data: {
+              disable_logout_target: 'confirmPassword',
+              action: 'input->disable-logout#toggleLogoutCheckbox'
+            } %>
+    </div>
+
+    <div class="mb-3">
+      <%= label_tag 'log_out_of_all_devices' do %>
+        <%= check_box_tag 'log_out_of_all_devices', '1', false, data: { disable_logout_target: 'logoutCheckbox' } %>
+        <%= t('.log_out_of_all_devices', default: 'Log out of all devices') %>
+      <% end %>
+    </div>
   </div>
 
   <%= f.submit "Update Profile", class: "btn btn-primary" %>

--- a/bin/importmap
+++ b/bin/importmap
@@ -1,0 +1,4 @@
+#!/usr/bin/env ruby
+
+require_relative "../config/application"
+require "importmap/commands"

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -1,0 +1,6 @@
+# Pin npm packages by running ./bin/importmap
+
+pin "application"
+pin "@hotwired/stimulus", to: "stimulus.min.js"
+pin "@hotwired/stimulus-loading", to: "stimulus-loading.js"
+pin_all_from "app/javascript/controllers", under: "controllers"

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -71,4 +71,9 @@ RSpec.configure do |config|
   # config.filter_gems_from_backtrace("gem name")
   config.include Devise::Test::ControllerHelpers, type: :controller
   config.include FactoryBot::Syntax::Methods
+  config.include Devise::Test::IntegrationHelpers, type: :system
+
+  config.before(:each, type: :system) do
+    driven_by :rack_test
+  end
 end

--- a/spec/systems/user_profile.rb
+++ b/spec/systems/user_profile.rb
@@ -1,0 +1,76 @@
+require 'rails_helper'
+
+RSpec.describe 'User updates profile', type: :system do
+  let(:user) { create(:user, email: 'email@gmail.com', password: 'password') }
+
+  before do
+    sign_in user
+  end
+
+  scenario 'user redirects to login page after password change' do
+    visit root_path
+
+    expect(page).to have_content('Welcome email@gmail.com')
+
+    click_button 'Edit Profile'
+
+    fill_in 'Current password', with: user.password
+    fill_in 'Password', with: 'new_password'
+    fill_in 'Password confirmation', with: 'new_password'
+    click_button 'Update'
+
+    expect(page).to have_content('You need to sign in or sign up before continuing.')
+    expect(page).to have_content('Log in')
+  end
+
+  context 'when keep logged in checked' do
+    scenario 'user redirects to root page after password change' do
+      visit root_path
+
+      expect(page).to have_content('Welcome email@gmail.com')
+
+      click_button 'Edit Profile'
+
+      fill_in 'Current password', with: user.password
+      fill_in 'Password', with: 'new_password'
+      fill_in 'Password confirmation', with: 'new_password'
+      check 'Keep logged in on this browser?'
+      click_button 'Update'
+
+      expect(page).to have_content('Welcome email@gmail.com')
+    end
+  end
+
+  context 'when update email only' do
+    scenario 'user redirects to root page after password change' do
+      visit root_path
+
+      expect(page).to have_content('Welcome email@gmail.com')
+
+      click_button 'Edit Profile'
+
+      fill_in 'Email', with: 'email1@gmail.com'
+      click_button 'Update'
+
+      expect(page).to have_content('You have to confirm your email address before continuing.')
+      expect(page).to have_content('Log in')
+    end
+  end
+
+  context 'when update profile with invalid data' do
+    scenario 'user redirects to root page after password change' do
+      visit root_path
+
+      expect(page).to have_content('Welcome email@gmail.com')
+
+      click_button 'Edit Profile'
+
+      fill_in 'Current password', with: user.password
+      fill_in 'Password', with: 'new_password1'
+      fill_in 'Password confirmation', with: 'new_password2'
+      click_button 'Update'
+
+      expect(page).to have_content("Password confirmation doesn't match Password")
+    end
+  end
+end


### PR DESCRIPTION
### PR Description
This PR improves the user profile update experience by ensuring that users stay signed in after changing their password.

**Summary**
- Added logic to **retain the current session after a successful password change** using `Devise`’s `bypass_sign_in`.
- Enhances user experience by avoiding unexpected sign-outs after password updates.
- Provides flexibility: only keeps session active when `keep_logged_in` is explicitly requested.